### PR TITLE
hexToBytes already substring removes '0x' if present.

### DIFF
--- a/src/services/common/signatures/jwt.ts
+++ b/src/services/common/signatures/jwt.ts
@@ -65,7 +65,7 @@ export class JWTService implements SignatureService {
      */
     convertKeys(keys: DIDWithKeys): Issuer {
         const pk = keys.keyPair.privateKey
-        const key = isString(pk) ? hexToBytes(pk.substring(2)): pk
+        const key = isString(pk) ? hexToBytes(pk): pk
         let signer
         switch(keys.keyPair.algorithm) {
             case KEY_ALG.ES256K: {


### PR DESCRIPTION
Merge bugfix in convertKeys